### PR TITLE
Block preview comment on YouTube desktop

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -44,6 +44,7 @@ ytm-engagement-panel,
 ytd-comments,
 ytd-comment-thread-renderer,
 ytd-comment-renderer,
+ytd-comments-entry-point-header-renderer,
 
 /* Disqus */
 a[data-disqus-identifier],

--- a/shutup.css
+++ b/shutup.css
@@ -782,6 +782,10 @@ table.ttxt2 td.ctxt,
 /* 1plus1.video */
 ._opo_-playlist-comments,
 
+/* Stack Exchange sites (e.g., Stack Overflow) */
+[itemprop="commentCount"],
+.js-post-comments-component,
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],


### PR DESCRIPTION
See https://github.com/panicsteve/shutup-css/pull/165 for more details.