### PR TITLE
Remove comment counts for formel1.de and golem.de

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -102,6 +102,9 @@ div#coral_thread,         /* v5 */
 .commentarea,
 shreddit-comment-tree,
 shreddit-comment,
+comment-body-header,
+shreddit-comments-page-ad,
+faceplate-batch[target="#comment-tree"],
 
 /* Designer News */
 #story-comments,
@@ -793,6 +796,9 @@ table.ttxt2 td.ctxt,
 /* LeagueofComicGeeks.com */
 #comic-details #reviews,
 #comic-details #discussion,
+
+/* theage.com.au */
+[data-testid="comments-cta"],
 
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],

--- a/shutup.css
+++ b/shutup.css
@@ -204,6 +204,10 @@ a.commentCountLink,
 p.theme-comments,
 #comments-speech-bubble-top,
 #comments-speech-bubble-bottom,
+#comments-speech-bubble-header,
+#comments-speech-bubble-footer,
+#comments-speech-bubble-bigBottom,
+#comments-speech-bubble-inStoryMasthead,
 
 /* Wall Street Journal */
 #comments_sector,

--- a/shutup.css
+++ b/shutup.css
@@ -800,6 +800,13 @@ table.ttxt2 td.ctxt,
 /* theage.com.au */
 [data-testid="comments-cta"],
 
+/* formel1.de */
+.fa-comments,
+.btn-comments,
+
+/* golem.de */
+.icon-comments,
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],


### PR DESCRIPTION
Based on panicsteve/shutup-css#170.