### PR TITLE
Remove Cooking.NYTimes user comments

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -209,6 +209,9 @@ p.theme-comments,
 #comments-speech-bubble-bigBottom,
 #comments-speech-bubble-inStoryMasthead,
 
+/* cooking.nytimes.com */
+#userNotesMount,
+
 /* Wall Street Journal */
 #comments_sector,
 #article-comments-tool,


### PR DESCRIPTION
Based on panicsteve/shutup-css#171.