### PR TITLE
Block kaleva.fi and yle.fi comments and comment count indicators

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -798,6 +798,7 @@ div.gh-comments,
 
 /* yle.fi */
 #yle-comments-plugin,
+p[class^="TuoreimmatItem__CommentTypography"],
 
 /* kaleva.fi */
 .m-contentListItem__discussion,

--- a/shutup.css
+++ b/shutup.css
@@ -796,6 +796,15 @@ div.gh-comments,
 /* Substack */
 #comments-for-scroll,
 
+/* yle.fi */
+#yle-comments-plugin,
+
+/* kaleva.fi */
+.m-contentListItem__discussion,
+.__widget_DiscussionByline,
+.__widget_DiscussionButton,
+.discussion-container,
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],


### PR DESCRIPTION
Based on panicsteve/shutup-css#196