### PR TITLE
Update shutup.css, adding classes for the UOL Brazilian portal.

### DIFF
--- a/shutup.css
+++ b/shutup.css
@@ -806,6 +806,9 @@ p[class^="TuoreimmatItem__CommentTypography"],
 .__widget_DiscussionButton,
 .discussion-container,
 
+/* uol.com.br */
+section.solar-comment,
+
 /* Various shady sites */
 .content form ~ a#ci ~ div[id^=c0],
 .content form ~ a#ci ~ div[id^=c1],


### PR DESCRIPTION
Based on panicsteve/shutup-css#197.